### PR TITLE
Always attach the clubhouse url even if there isn't a placeholder for it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+        args: [--branch, master]
+
+  - repo: git://github.com/detailyang/pre-commit-shell
+    sha: 1.0.4
+    hooks:
+      - id: shell-lint

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -17,6 +17,8 @@ if [[ -n "$ticket" ]]; then
     ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
 fi
 
+echo Found CH ticket number "${ticket}"
+
 link_url="$STORY_BASE_URL/$ticket"
 
 new_body=${body/$STORY_LINK_TEXT/$link_url}

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -2,9 +2,7 @@
 
 OK=ok.sh
 
-event=$(cat "$GITHUB_EVENT_PATH")
 number=$(jq -r .number "$GITHUB_EVENT_PATH")
-action=$(jq -r .action "$GITHUB_EVENT_PATH")
 body=$(jq -r .pull_request.body "$GITHUB_EVENT_PATH")
 body=${body//$'\r'/} # Remove /r, which confuses jq in ok.sh
 title=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
@@ -45,6 +43,6 @@ machine api.github.com
     password $GITHUB_TOKEN
 EOF
 
-if [[ "$ticket" != "" ]] && ([[ "$body" != "$new_body" ]] || [[ "$title" != "$new_title" ]]); then
+if [[ "$ticket" != "" && ( "$body" != "$new_body" || "$title" != "$new_title" ) ]]; then
     "$OK" update_pull_request "$GITHUB_REPOSITORY" "$number" "body='$new_body'" "title='$new_title'"
 fi

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -10,10 +10,23 @@ body=${body//$'\r'/} # Remove /r, which confuses jq in ok.sh
 title=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
 title=${title//$'\r'/} # Remove /r, which confuses jq in ok.sh
 
-ticket=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
+ticket_from_title=$(expr "$title" : '.*ch\([[:digit:]]*\).*')
+ticket_from_branch=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
+
+# Check title first for the CH ticket
+ticket="$ticket_from_title"
+if [[ -n "$ticket" ]]; then
+    ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
+fi
+
 link_url="$STORY_BASE_URL/$ticket"
 
 new_body=${body/$STORY_LINK_TEXT/$link_url}
+
+# If we still don't have the url in the body, tack it on the beginning
+if [[ "$new_body" != *"$link_url"* ]]; then
+    new_body="$link_url\n$new_body"
+fi
 
 # Strip out branch name from the PR title
 new_title="${title/$GITHUB_REF/}"
@@ -21,8 +34,8 @@ new_title="${title/$GITHUB_REF/}"
 # Strip out uppercase branch name
 new_title="${new_title/${GITHUB_REF^}/}"
 
-# Add the clubhouse number to the PR title
-if [[ ! "$new_title" =~ "$ticket" ]]; then
+# Add the clubhouse number to the PR title if it isn't already there
+if [[ "$new_title" != *"$ticket"* ]]; then
     new_title="[ch${ticket}] $new_title"
 fi
 

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -15,11 +15,10 @@ ticket_from_branch=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
 
 # Check title first for the CH ticket
 ticket="$ticket_from_title"
+echo "Found CH ticket number '${ticket_from_title}' in PR title"
 if [[ -z "$ticket" ]]; then
     ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
     echo "Found CH ticket number '${ticket}' in branch name"
-else
-    echo "Found CH ticket number '${ticket}' in PR title"
 fi
 
 link_url="$STORY_BASE_URL/$ticket"

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -17,7 +17,7 @@ if [[ -z "$ticket" ]]; then
     ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
 fi
 
-echo Found CH ticket number "${ticket}"
+echo "Found CH ticket number '${ticket}'"
 
 link_url="$STORY_BASE_URL/$ticket"
 

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -8,6 +8,8 @@ body=${body//$'\r'/} # Remove /r, which confuses jq in ok.sh
 title=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
 title=${title//$'\r'/} # Remove /r, which confuses jq in ok.sh
 
+echo "Current PR title is '${title}'"
+
 ticket_from_title=$(expr "$title" : '.*ch\([[:digit:]]*\).*')
 ticket_from_branch=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
 

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -10,15 +10,17 @@ title=${title//$'\r'/} # Remove /r, which confuses jq in ok.sh
 
 echo "Current PR title is '${title}'"
 
-ticket_from_title=$(expr "$title" : '.*ch\([[:digit:]]*\).*')
-ticket_from_branch=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
+pattern='.*\bch\([[:digit:]]\+\)\b.*'
+ticket_from_title=$(expr "$title" : "$pattern")
+ticket_from_branch=$(expr "$GITHUB_REF" : "$pattern")
 
 # Check title first for the CH ticket
 ticket="$ticket_from_title"
-echo "Found CH ticket number '${ticket_from_title}' in PR title"
 if [[ -z "$ticket" ]]; then
     ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
     echo "Found CH ticket number '${ticket}' in branch name"
+else
+    echo "Found CH ticket number '${ticket}' in PR title"
 fi
 
 link_url="$STORY_BASE_URL/$ticket"

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -13,7 +13,7 @@ ticket_from_branch=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
 
 # Check title first for the CH ticket
 ticket="$ticket_from_title"
-if [[ -n "$ticket" ]]; then
+if [[ -z "$ticket" ]]; then
     ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
 fi
 

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -15,9 +15,10 @@ ticket_from_branch=$(expr "$GITHUB_REF" : '.*ch\([[:digit:]]*\).*')
 ticket="$ticket_from_title"
 if [[ -z "$ticket" ]]; then
     ticket="$ticket_from_branch" # fall back to the CH ticket # from the branch
+    echo "Found CH ticket number '${ticket}' in branch name"
+else
+    echo "Found CH ticket number '${ticket}' in PR title"
 fi
-
-echo "Found CH ticket number '${ticket}'"
 
 link_url="$STORY_BASE_URL/$ticket"
 


### PR DESCRIPTION
Also get the ticket # from the PR title if it's available and give it
precedence over the branch name so the user has maximum flexibility.