### PR TITLE
Support github autolink prefixes and other improvements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+<!-- Story link goes here. If you named your branch using the Clubhouse suggested name, this link will autopopulate. -->

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,3 +13,10 @@ jobs:
           AUTOLINK_PREFIX: CH-
           STORY_LINK_TEXT: <!-- Story link goes here. If you named your branch using the Clubhouse suggested name, this link will autopopulate. -->
           CREATE_STORY_URL: https://app.clubhouse.io/testing/stories/new?template_id=5d3749a8-93bf-48e1-b8fc-1bfa7c74a625
+      - name: Set Clubhouse Link in comment
+        uses: ./set-ch-link
+        env:
+          COMMENT_ONLY: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CREATE_STORY_URL: https://app.clubhouse.io/testing/stories/new?template_id=5d3749a8-93bf-48e1-b8fc-1bfa7c74a625
+          STORY_BASE_URL: https://app.clubhouse.io/testing/story

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,15 @@
+on: pull_request
+name: Pull request
+jobs:
+  setClubhouseLinkInPR:
+    name: Set Clubhouse Link in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set Clubhouse Link in PR
+        uses: ./set-ch-link
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOLINK_PREFIX: CH-
+          STORY_LINK_TEXT: <!-- Story link goes here. If you named your branch using the Clubhouse suggested name, this link will autopopulate. -->
+          CREATE_STORY_URL: https://app.clubhouse.io/testing/stories/new?template_id=5d3749a8-93bf-48e1-b8fc-1bfa7c74a625

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: no-commit-to-branch
-        args: [--branch, master]
 
   - repo: git://github.com/detailyang/pre-commit-shell
-    sha: 1.0.4
+    rev: 1.0.5
     hooks:
       - id: shell-lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Clubhouse Ticket Link Action
 
-It adds a link to the ticket for the PR and adds the CH to the title.  Add this to a `.yml` file in `.github/workflows/` to enable as follows:
+It adds a link to the ticket for the PR and adds the CH to the title.
+
+Options:
+
+  * `AUTOLINK_PREFIX` - Set this instead of STORY_BASE_URL if you just want to rely on github's prefix-based autolinking feature to create links
+  * `COMMENT_ONLY` - Set this to "1" just add a comment with a Clubhouse link and only do it when a PR is first opened.  This avoids conflicts that
+    could cause you to lose manually PR description changes made while the github action is running.
+
+Add this to a `.yml` file in `.github/workflows/` to enable as follows:
 
 ```
 on: pull_request
@@ -17,5 +25,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         STORY_BASE_URL: https://app.clubhouse.io/launchdarkly/story
         STORY_LINK_TEXT: <!-- Story link goes here -->
+        AUTOLINK_PREFIX: "CH-"
         CREATE_TICKET_URL: https://app.clubhouse.io/launchdarkly/stories/new?template_id=<xxxxxx-xxxx-xxxx-xxxxxxxxxxx>
 ```

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -62,7 +62,7 @@ if [[ "$new_body" != *"$link_url"* ]] && [[ -n "$story" ]] ; then
     new_body="$link_url\n$new_body"
 fi
 
-branch_with_spaces_for_dashes="${branch//[_-]/}"
+branch_with_spaces_for_dashes="${branch//[_-]/ }"
 
 # Strip out branch name from the PR title
 new_title="${title/$branch/}"

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -62,11 +62,15 @@ if [[ "$new_body" != *"$link_url"* ]] && [[ -n "$story" ]] ; then
     new_body="$link_url\n$new_body"
 fi
 
+branch_with_spaces_for_dashes="${branch//[_-]/}"
+
 # Strip out branch name from the PR title
 new_title="${title/$branch/}"
+new_title="${title/$branch_with_spaces_for_dashes/}"
 
 # Strip out uppercase branch name
 new_title="${new_title/${branch^}/}"
+new_title="${new_title/${branch_with_spaces_for_dashes^}/}"
 
 # Add the clubhouse number to the PR title if it isn't already there
 if [[ "$new_title" != *"$story"* ]]; then

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -29,9 +29,14 @@ link_pattern='.*\story/\([[:digit:]]\+\)\b.*'
 story_from_body=$(expr "$body" : "$pattern")
 story_from_body_link=$(expr "$body" : "$link_pattern")
 
+if [[ -n "$AUTOLINK_PREFIX" ]]; then
+  autolink_pattern="${AUTOLINK_PREFIX}([[:digit:]]\+\)\b.*"
+  story_from_autolink=$(expr "$body" : "$autolink_pattern")
+fi
+
 # Check title first for the CH story
 # shellcheck disable=SC2206
-stories=($story_from_title $story_from_branch $story_from_body $story_from_body_link)
+stories=($story_from_title $story_from_branch $story_from_body $story_from_autolink $story_from_body_link)
 story="${stories[0]}"
 
 if [[ -z "$story" ]]; then
@@ -40,7 +45,13 @@ else
     echo "Found CH story number '${story}'"
 fi
 
-link_url="$STORY_BASE_URL/$story"
+# If we have an autolink prefix to use, we use that instead of a link
+# See https://help.github.com/en/github/administering-a-repository/configuring-autolinks-to-reference-external-resources
+if [[ -n "$AUTOLINK_PREFIX" ]]; then
+  link_url="$AUTOLINK_PREFIX$story"
+else
+  link_url="$STORY_BASE_URL/$story"
+fi
 
 if [[ -n "$story" ]]; then
     new_body=${body/$STORY_LINK_TEXT/$link_url} # replace the story link text
@@ -68,7 +79,7 @@ machine api.github.com
     password $GITHUB_TOKEN
 EOF
 
-if [[ "$story" != "" && ( "$body" != "$new_body"  || "$title" != "$new_title" ) ]]; then
+if [[ "$story" != "" && ( "$body" != "$new_body" || "$title" != "$new_title" ) ]]; then
     args=("title='$new_title'")
     if [[ "$COMMENT_ONLY" != "1" ]]; then
         args+=("body='$new_body'")

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -85,7 +85,7 @@ if [[ "$story" != "" && ( "$body" != "$new_body" || "$title" != "$new_title" ) ]
         args+=("body='$new_body'")
     fi
     "$OK" update_pull_request "$GITHUB_REPOSITORY" "$number" "${args[@]}"
-    if [[ "$COMMENT_ONLY" == "1"  ]]; then
+    if [[ "$COMMENT_ONLY" == "1" && "$action" == "opened" ]]; then
         "$OK" add_comment "$GITHUB_REPOSITORY" "$number" "CH link is $link_url."
     fi
 fi

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -68,8 +68,15 @@ machine api.github.com
     password $GITHUB_TOKEN
 EOF
 
-if [[ "$story" != "" && ( "$body" != "$new_body" || "$title" != "$new_title" ) ]]; then
-    "$OK" update_pull_request "$GITHUB_REPOSITORY" "$number" "body='$new_body'" "title='$new_title'"
+if [[ "$story" != "" && ( "$body" != "$new_body"  || "$title" != "$new_title" ) ]]; then
+    args=("title='$new_title'")
+    if [[ "$COMMENT_ONLY" != "1" ]]; then
+        args+=("body='$new_body'")
+    fi
+    "$OK" update_pull_request "$GITHUB_REPOSITORY" "$number" "${args[@]}"
+    if [[ "$COMMENT_ONLY" == "1"  ]]; then
+        "$OK" add_comment "$GITHUB_REPOSITORY" "$number" "CH link is $link_url."
+    fi
 fi
 
 # If we have no story add a comment to create one

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -30,7 +30,7 @@ story_from_body=$(expr "$body" : "$pattern")
 story_from_body_link=$(expr "$body" : "$link_pattern")
 
 if [[ -n "$AUTOLINK_PREFIX" ]]; then
-  autolink_pattern="${AUTOLINK_PREFIX}([[:digit:]]\+\)\b.*"
+  autolink_pattern="${AUTOLINK_PREFIX}\([[:digit:]]\+\)\b.*"
   story_from_autolink=$(expr "$body" : "$autolink_pattern")
 fi
 


### PR DESCRIPTION
* Use AUTOLINK_PREFIX to allow use of autolink prefixes for tickets instead of inserting a full url
* Add a COMMENT_ONLY mode
* Also eliminate underscores and dashes when stripping branch names from titles.