### PR TITLE
Update readme to include public/private example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Options:
 
 Add this to a `.yml` file in `.github/workflows/` to enable as follows:
 
-```
+``` yaml
 on: pull_request
 name: Pull request
 jobs:
@@ -18,7 +18,27 @@ jobs:
     name: Set Clubhouse Link in PR
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Set Clubhouse Link in PR
+      uses: launchdarkly/ld-gh-actions-clubhouse/set-ch-link@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        STORY_BASE_URL: https://app.clubhouse.io/launchdarkly/story
+        STORY_LINK_TEXT: <!-- Story link goes here -->
+        AUTOLINK_PREFIX: "CH-"
+        CREATE_TICKET_URL: https://app.clubhouse.io/launchdarkly/stories/new?template_id=<xxxxxx-xxxx-xxxx-xxxxxxxxxxx>
+```
+
+If your repository is mirrored (i.e. public/private) and you only want the action to run on one of the repositories, include an [`if` conditional](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif) at the job level:
+
+``` yaml
+on: pull_request
+name: Pull request
+jobs:
+  setClubhouseLinkInPR:
+    if: github.repository == 'org-name/mirrored-repo-private'
+    name: Set Clubhouse Link in PR
+    runs-on: ubuntu-latest
+    steps:
     - name: Set Clubhouse Link in PR
       uses: launchdarkly/ld-gh-actions-clubhouse/set-ch-link@master
       env:


### PR DESCRIPTION
<!-- Story link goes here. If you named your branch using the Clubhouse suggested name, this link will autopopulate. -->
I tested this out on one of my repos and it works as expected.

I also got rid of the `- uses: actions/checkout@master` because I don't think that it's needed for this.

Job level if condtionals are new as of [10/1/2019](https://github.blog/changelog/2019-10-01-github-actions-new-workflow-syntax-features/). 