### PR TITLE
Add SKIP_LINK option to skip adding comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Options:
   * `AUTOLINK_PREFIX` - Set this instead of STORY_BASE_URL if you just want to rely on github's prefix-based autolinking feature to create links
   * `COMMENT_ONLY` - Set this to "1" just add a comment with a Clubhouse link and only do it when a PR is first opened.  This avoids conflicts that
     could cause you to lose manually PR description changes made while the github action is running.
+  * `SKIP_LINK` - Set this to "1" to avoid adding a link either in a comment or in the body.
 
 Add this to a `.yml` file in `.github/workflows/` to enable as follows:
 

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -85,11 +85,11 @@ EOF
 
 if [[ "$story" != "" && ( "$body" != "$new_body" || "$title" != "$new_title" ) ]]; then
     args=("title='$new_title'")
-    if [[ "$COMMENT_ONLY" != "1" ]]; then
+    if [[ "$COMMENT_ONLY" != "1" && "$SKIP_LINK" != "1" ]]; then
         args+=("body='$new_body'")
     fi
     "$OK" update_pull_request "$GITHUB_REPOSITORY" "$number" "${args[@]}"
-    if [[ "$COMMENT_ONLY" == "1" && "$SKIP_COMMENT" != "1" && "$action" == "opened" ]]; then
+    if [[ "$COMMENT_ONLY" == "1" && "$SKIP_LINK" != "1" && "$action" == "opened" ]]; then
         "$OK" add_comment "$GITHUB_REPOSITORY" "$number" "CH link is $link_url."
     fi
 fi

--- a/set-ch-link/entrypoint.sh
+++ b/set-ch-link/entrypoint.sh
@@ -89,7 +89,7 @@ if [[ "$story" != "" && ( "$body" != "$new_body" || "$title" != "$new_title" ) ]
         args+=("body='$new_body'")
     fi
     "$OK" update_pull_request "$GITHUB_REPOSITORY" "$number" "${args[@]}"
-    if [[ "$COMMENT_ONLY" == "1" && "$action" == "opened" ]]; then
+    if [[ "$COMMENT_ONLY" == "1" && "$SKIP_COMMENT" != "1" && "$action" == "opened" ]]; then
         "$OK" add_comment "$GITHUB_REPOSITORY" "$number" "CH link is $link_url."
     fi
 fi


### PR DESCRIPTION
The clubhouse integration now adds a comment including a link so we don't need to.

<!-- Story link goes here. If you named your branch using the Clubhouse suggested name, this link will autopopulate. -->
