### PR TITLE
Add hyphen to branch pattern

### DIFF
--- a/set-link/entrypoint.sh
+++ b/set-link/entrypoint.sh
@@ -21,7 +21,7 @@ branch=$(jq -r .pull_request.head.ref "$GITHUB_EVENT_PATH")
 echo "Current PR title is '${title}'"
 echo "Github branch is '$branch'"
 
-pattern='.*\bsc-?\([[:digit:]]\+\)\b.*'
+pattern='.*\bsc-\{0,1\}\([[:digit:]]\+\)\b.*'
 story_from_title=$(expr "$title" : "$pattern")
 story_from_branch=$(expr "$branch" : "$pattern")
 

--- a/set-link/entrypoint.sh
+++ b/set-link/entrypoint.sh
@@ -21,7 +21,7 @@ branch=$(jq -r .pull_request.head.ref "$GITHUB_EVENT_PATH")
 echo "Current PR title is '${title}'"
 echo "Github branch is '$branch'"
 
-pattern='.*\bsc-\([[:digit:]]\+\)\b.*'
+pattern='.*\bsc-?\([[:digit:]]\+\)\b.*'
 story_from_title=$(expr "$title" : "$pattern")
 story_from_branch=$(expr "$branch" : "$pattern")
 

--- a/set-link/entrypoint.sh
+++ b/set-link/entrypoint.sh
@@ -74,7 +74,7 @@ new_title="${new_title/${branch_with_spaces_for_dashes^}/}"
 
 # Add the story number to the PR title if it isn't already there
 if [[ "$new_title" != *"$story"* ]]; then
-    new_title="[sc${story}] $new_title"
+    new_title="[sc-${story}] $new_title"
 fi
 
 cat > ~/.netrc <<-EOF

--- a/set-link/entrypoint.sh
+++ b/set-link/entrypoint.sh
@@ -21,7 +21,7 @@ branch=$(jq -r .pull_request.head.ref "$GITHUB_EVENT_PATH")
 echo "Current PR title is '${title}'"
 echo "Github branch is '$branch'"
 
-pattern='.*\bsc\([[:digit:]]\+\)\b.*'
+pattern='.*\bsc-\([[:digit:]]\+\)\b.*'
 story_from_title=$(expr "$title" : "$pattern")
 story_from_branch=$(expr "$branch" : "$pattern")
 


### PR DESCRIPTION
<!-- Story link goes here. If you named your branch using the Shortcut suggested name, this link will autopopulate. -->
I was running into some issues trying to get this action to work witch shortcut links an a few of our team's repos. I think the issue is we are missing a hyphen in the branch pattern. There is a chance I'm just mis-configuring the action, so this may not be needed. 