### PR TITLE
[sc-214812] use curl instead of wget

### DIFF
--- a/set-link/Dockerfile
+++ b/set-link/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine
 
-RUN apk add --no-cache bash jq curl wget
+RUN apk add --no-cache bash jq curl
 
 ARG OK_SH_VERSION=0.7.0
 
 # Install ok.sh, a bash github client
 RUN cd /tmp && \
-    wget https://github.com/whiteinge/ok.sh/archive/${OK_SH_VERSION}.tar.gz -O ok.tar.gz && \
+    curl -L https://github.com/whiteinge/ok.sh/archive/${OK_SH_VERSION}.tar.gz -o ok.tar.gz && \
     tar xvf ok.tar.gz && \
     cp ok.sh-${OK_SH_VERSION}/ok.sh /usr/bin/ && \
     chmod +x /usr/bin/ok.sh


### PR DESCRIPTION
[SC-214812](https://app.shortcut.com/launchdarkly/story/214812/ld-gh-actions-shortcut-wget-started-failling)

Let's use `curl` instead of `wget` after it started failing to retrieve Github archives with a 403 error.